### PR TITLE
Hide variable inside process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Envinject
 
 
-Optionally inject variables into the environment. Currently supports
+Optionally inject variables into an environment structure that allows 
+reading like a 12 factor app, but without making the parameters available
+via docker inspect. This allows injecting secrets without making it super
+easy to obtain the secrets from the command line.
+
+Currently supports
 pulling AWS SSM Parameters with a given prefix into the environment.
 
 The goal is to be able to write code that can get its configuration from
@@ -9,7 +14,7 @@ the environment, with the values in the environment potentially injected
 with values from some configuration store like the AWS SSM Parameter
 store.
 
-The InjectEnv function is the mechanism to inject AWS parameter store
+The InjectEnv type is the mechanism to inject AWS parameter store
 values into the environment. If the AWS_PARAM_STORE_PREFIX environment 
 variable is set, the code will attempt to read parameters from the 
 parameter store, injecting the parameters with names statring with the 
@@ -18,6 +23,11 @@ AWS_PARAM_STORE_PREFIX is set to `foo-`, any variables starting with
 `foo-` are injected into the environmen: `foo-var1` is injected as `var1`,
 `foo-var2` is injected as `var2`, and so on. All other parameters are 
 ignored.
+
+If AWS_PARAM_STORE_PREFIX is not set, then the class acts as a pass
+through, reading variables from environment variables. This is useful
+when using a container workflow that does not include the use of 
+AWS services.
 
 To illustrate how this works for tasks run on an ECS cluster, a 
 sample os provided. Built the sample via the provided Makefile, or just

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ the environment, with the values in the environment potentially injected
 with values from some configuration store like the AWS SSM Parameter
 store.
 
+## Usage
+
+For pass through use, simply instantiate InjectEnv with an empty
+AWS_PARAM_STORE_PREFIX and use the methods on the type to read 
+configuration set as environment variables.
+
+To read parameter store variables, store the variables using a 
+prefix in front of each environment variable name (which serves as
+a namespace or environment tag), set AWS_PARAM_STORE_PREFIX
+to the prefix, and run your app. You'll need to configure your
+environment to pick up AWS credentials, which is done in the usual
+way.
+
 The InjectEnv type is the mechanism to inject AWS parameter store
 values into the environment. If the AWS_PARAM_STORE_PREFIX environment 
 variable is set, the code will attempt to read parameters from the 

--- a/envinject.go
+++ b/envinject.go
@@ -37,7 +37,7 @@ func makeInjectedEnv() *InjectedEnv {
 }
 
 func (i *InjectedEnv) InjectVar(name, value string) {
-	if i.passThrough == true {
+	if i.passThrough != true {
 		i.environment[name] = value
 	}
 }

--- a/envinject.go
+++ b/envinject.go
@@ -2,23 +2,101 @@ package envinject
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"os"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws"
 	"strings"
+	"fmt"
+	"os"
 )
 
 
 const ParamPrefixEnvVar = "AWS_PARAM_STORE_PREFIX"
 
-func InjectEnv() error {
+type InjectedEnv struct {
+	passThrough bool
+	environment map[string]string
+}
+
+func makePassThroughEnv() *InjectedEnv {
+	injectEnv := InjectedEnv {
+		passThrough:true,
+		environment: make(map[string]string),
+	}
+
+	return &injectEnv
+}
+
+func makeInjectedEnv() *InjectedEnv {
+	injectEnv := InjectedEnv {
+		passThrough:false,
+		environment: make(map[string]string),
+	}
+
+	return &injectEnv
+}
+
+func (i *InjectedEnv) InjectVar(name, value string) {
+	if i.passThrough == true {
+		i.environment[name] = value
+	}
+}
+
+
+// Getenv retrieves the value of the environment variable named by the key.
+// It returns the value, which will be empty if the variable is not present.
+// To distinguish between an empty value and an unset value, use LookupEnv.
+// Note: spec borrowed from golang.org os.Getenv
+func (i *InjectedEnv) Getenv(name string) string {
+	if i.passThrough == true {
+		return os.Getenv(name)
+	}
+
+	return i.environment[name]
+}
+
+// LookupEnv retrieves the value of the environment variable named by the key. If
+// the variable is present in the environment the value (which may be empty)
+// is returned and the boolean is true. Otherwise the returned
+// value will be empty and the boolean will be false.
+// Note: spec borrowed from golang.org os.LookupEnv
+func (i *InjectedEnv) LookupEnv(name string) (string,bool) {
+	if i.passThrough == true {
+		return os.LookupEnv(name)
+	}
+
+	v,ok := i.environment[name]
+	return v,ok
+}
+
+func (i *InjectedEnv)  Environ() []string {
+	if i.passThrough == true {
+		return os.Environ()
+	}
+
+	var env []string
+	for k,v := range i.environment {
+		env = append(env,
+			fmt.Sprintf("%s=%s", k, v),
+		)
+	}
+
+	return env
+}
+// Environ returns a copy of strings representing the environment, in the form "key=value".
+// Note: spec borrowed from golang.org os.Environ
+
+
+
+
+
+func NewInjectedEnv() (*InjectedEnv,error) {
 
 	//Need a parameter prefix if we are reading from the SSM parameter store
 	prefix := os.Getenv(ParamPrefixEnvVar)
 	if prefix == "" {
 		log.Infof("%s env variable not set - reading configuration from os environment.", ParamPrefixEnvVar)
-		return nil
+		return makePassThroughEnv(),nil
 	}
 
 	//Parameter store is indicated - create a session
@@ -28,7 +106,7 @@ func InjectEnv() error {
 
 	sess, err := session.NewSession()
 	if err != nil {
-		return err
+		return nil,err
 	}
 
 	//Read the params and inject them into the environment
@@ -36,13 +114,15 @@ func InjectEnv() error {
 
 	params := &ssm.DescribeParametersInput{}
 
+	injected := makeInjectedEnv()
+
 	for {
 		resp, err := svc.DescribeParameters(params)
 
 		if err != nil {
 			// Print the error, cast err to awserr.Error to get the Code and
 			// Message from an error.
-			return err
+			return nil,err
 		}
 
 		parameterMetadata := resp.Parameters
@@ -64,11 +144,11 @@ func InjectEnv() error {
 			}
 			resp, err := svc.GetParameters(params)
 			if err != nil {
-				return err
+				return nil,err
 			}
 
 			paramVal := resp.Parameters[0].Value
-			os.Setenv(keyMinusPrefix, *paramVal)
+			injected.InjectVar(keyMinusPrefix, *paramVal)
 		}
 
 		nextToken := resp.NextToken
@@ -83,5 +163,6 @@ func InjectEnv() error {
 
 	}
 
-	return nil
+	return injected,nil
+
 }

--- a/envinject_test.go
+++ b/envinject_test.go
@@ -1,0 +1,65 @@
+package envinject
+
+import (
+	"testing"
+	"os"
+	"github.com/stretchr/testify/assert"
+)
+
+func setNoParamStore() {
+	os.Setenv(ParamPrefixEnvVar,"")
+}
+
+func setEnv() {
+	setNoParamStore()
+	os.Setenv("foo", "foo val")
+	os.Setenv("bar", "bar val")
+}
+
+func TestPassthroughGetenv(t *testing.T) {
+	setEnv()
+
+	i,err := NewInjectedEnv()
+
+	if assert.Nil(t,err) {
+		assert.Equal(t, "foo val", i.Getenv("foo"))
+		assert.Equal(t, "bar val", i.Getenv("bar"))
+	}
+}
+
+func TestPassthroughLookupEnv(t *testing.T) {
+	setEnv()
+
+	i,err := NewInjectedEnv()
+
+	if assert.Nil(t,err) {
+		foo,hasFoo := i.LookupEnv("foo")
+		assert.Equal(t, "foo val", foo)
+		assert.Equal(t, true, hasFoo)
+
+		baz, hasBaz := i.LookupEnv("baz")
+		assert.Equal(t, "", baz)
+		assert.Equal(t, false, hasBaz)
+	}
+}
+
+func sliceContains(slice []string, s string) bool {
+	for _,v := range slice {
+		if v == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestPassthroughEnvironment(t *testing.T) {
+	setEnv()
+	i,err := NewInjectedEnv()
+	if assert.Nil(t,err) {
+		e := i.Environ()
+		assert.True(t, sliceContains(e, "foo=foo val"))
+		assert.True(t, sliceContains(e, "bar=bar val"))
+	}
+
+}

--- a/internal/features/inject/injectenv.feature
+++ b/internal/features/inject/injectenv.feature
@@ -1,0 +1,6 @@
+@injectfeature
+Feature: Parameter injection
+  Scenario:
+    Given some configuration store in the SSM parameter store
+    When I create an inject environment
+    Then I can read my environment variables based on prefix

--- a/internal/features/inject/injectenv_steps.go
+++ b/internal/features/inject/injectenv_steps.go
@@ -14,6 +14,8 @@ import (
 func init() {
 	var env *envinject.InjectedEnv
 	Given(`^some configuration store in the SSM parameter store$`, func() {
+		log.Info("Assuming user has access to the default key for the account")
+
 		session, err := session.NewSession()
 		if err != nil {
 			T.Errorf(err.Error())
@@ -28,6 +30,18 @@ func init() {
 			Value:aws.String("p1Value"),
 		}
 		_, err = svc.PutParameter(&p1Input)
+		if err != nil {
+			T.Errorf(err.Error())
+			return
+		}
+
+		p2Input := ssm.PutParameterInput{
+			Name: aws.String("inttest-p2"),
+			Overwrite:aws.Bool(true),
+			Type:aws.String("SecureString"),
+			Value:aws.String("p2Value is secret"),
+		}
+		_, err = svc.PutParameter(&p2Input)
 		if err != nil {
 			T.Errorf(err.Error())
 			return
@@ -54,6 +68,8 @@ func init() {
 		}
 		p1 := env.Getenv("p1")
 		assert.Equal(T, "p1Value", p1)
+		p2 := env.Getenv("p2")
+		assert.Equal(T, "p2Value is secret", p2)
 	})
 
 }

--- a/internal/features/inject/injectenv_steps.go
+++ b/internal/features/inject/injectenv_steps.go
@@ -1,0 +1,59 @@
+package inject
+
+import (
+	. "github.com/gucumber/gucumber"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/aws"
+	"os"
+	"github.com/xtraclabs/envinject"
+	"github.com/stretchr/testify/assert"
+	log "github.com/Sirupsen/logrus"
+)
+
+func init() {
+	var env *envinject.InjectedEnv
+	Given(`^some configuration store in the SSM parameter store$`, func() {
+		session, err := session.NewSession()
+		if err != nil {
+			T.Errorf(err.Error())
+			return
+		}
+
+		svc := ssm.New(session)
+		p1Input := ssm.PutParameterInput{
+			Name: aws.String("inttest-p1"),
+			Overwrite:aws.Bool(true),
+			Type:aws.String("String"),
+			Value:aws.String("p1Value"),
+		}
+		_, err = svc.PutParameter(&p1Input)
+		if err != nil {
+			T.Errorf(err.Error())
+			return
+		}
+
+	})
+
+	When(`^I create an inject environment$`, func() {
+		os.Setenv("AWS_PARAM_STORE_PREFIX","inttest-")
+		var err error
+		env,err = envinject.NewInjectedEnv()
+		if err != nil {
+			T.Errorf(err.Error())
+			return
+		}
+
+	})
+
+	Then(`^I can read my environment variables based on prefix$`, func() {
+		log.Info("dump env")
+		all := env.Environ()
+		for _,es:= range all {
+			log.Info(es)
+		}
+		p1 := env.Getenv("p1")
+		assert.Equal(T, "p1Value", p1)
+	})
+
+}

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,6 +1,9 @@
 container:
 	GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -o dumpos
-	docker build -t xtracdev/dumpos .
+	docker build -t xtracdev/dumpos:latest .
+
+push:
+	docker push xtracdev/dumpos latest
 
 clean:
 	rm -f dumpos

--- a/sample/main.go
+++ b/sample/main.go
@@ -2,19 +2,17 @@ package main
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"os"
 	"github.com/xtraclabs/envinject"
 )
 
 func main() {
-
-	err := envinject.InjectEnv()
+	injected, err := envinject.NewInjectedEnv()
 	if err != nil {
 		log.Warn(err.Error())
-	}
-
-	vars := os.Environ()
-	for _,v := range vars {
-		log.Info(v)
+	} else {
+		vars := injected.Environ()
+		for _,v := range vars {
+			log.Info(v)
+		}
 	}
 }


### PR DESCRIPTION
This modification is to allow an environment var based workflow for docker dev, with a prod config in AWS that hides secrets from docker inspect.